### PR TITLE
Fix for the CDN source link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <h1>Hello world!</h1>
   </script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="js/libs/jquery-1.6.1.min.js"%3E%3C/script%3E'))</script>
   <script src="js/libs/sproutcore-2.0.a.2.min.js"></script>
   <script src="js/app.js"></script>


### PR DESCRIPTION
We need to use 'http://' in the CDN links, otherwise a browser will use 'file://' in path 
