### PR TITLE
Link in index.html to jquery library is missing http-protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     {{/view}}
   </script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="js/libs/jquery-1.6.1.min.js"%3E%3C/script%3E'))</script>
   <script src="js/libs/sproutcore-2.0.a.3.min.js"></script>
   <script src="js/app.js"></script>


### PR DESCRIPTION
index.html contains a script tag to load the minified version of jquery library. The src tag, however, is missing the http protocol.
