### PR TITLE
Add missing "http:" on jquery cdn url

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     {{/view}}
   </script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="js/libs/jquery-1.6.1.min.js"%3E%3C/script%3E'))</script>
   <script src="js/libs/ember-0.9.3.min.js"></script>
   <script src="js/app.js"></script>


### PR DESCRIPTION
I found incorrect url on jquery cdn, so I current this.
